### PR TITLE
fix: fixed tests, transformed settings DI injection to options

### DIFF
--- a/SS14.Labeller.Tests/CustomWebApplicationFactory.cs
+++ b/SS14.Labeller.Tests/CustomWebApplicationFactory.cs
@@ -1,9 +1,12 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
+using SS14.Labeller.DiscourseApi;
 using SS14.Labeller.GitHubApi;
 
 namespace SS14.Labeller.Tests;
@@ -12,16 +15,30 @@ namespace SS14.Labeller.Tests;
 public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
     public IGitHubApiClient GitHubApiClient { get; private set; }
+    public IDiscourseClient DiscourseClient { get; private set; }
 
     /// <inheritdoc />
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         GitHubApiClient = Substitute.For<IGitHubApiClient>();
+        DiscourseClient = Substitute.For<IDiscourseClient>();
 
         base.ConfigureWebHost(builder);
         builder.ConfigureServices(sp =>
         {
             sp.Replace(new ServiceDescriptor(typeof(IGitHubApiClient), GitHubApiClient));
+            sp.Replace(new ServiceDescriptor(typeof(IDiscourseClient), DiscourseClient));
+        }).ConfigureAppConfiguration((context, configurationBuilder) =>
+        {
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Discourse:ApiKey", "wawa" },
+                { "Discourse:Username", "aw" },
+                { "Discourse:DiscussionCategoryId", "42" },
+                { "Discourse:Url", "http://wa.wa" },
+                { "GitHub:WebhookSecret", IntegrationTests.HookSecret },
+                { "GitHub:Token", "test-test" },
+            });
         });
     }
 }

--- a/SS14.Labeller.Tests/IntegrationTests.cs
+++ b/SS14.Labeller.Tests/IntegrationTests.cs
@@ -12,7 +12,7 @@ namespace SS14.Labeller.Tests;
 [ExcludeFromCodeCoverage]
 public partial class IntegrationTests
 {
-    private const string HookSecret = "asdasdasdasdasdasdasdadsadad";
+    public const string HookSecret = "asdasdasdasdasdasdasdadsadad";
 
     private CustomWebApplicationFactory _applicationFactory;
 
@@ -21,14 +21,6 @@ public partial class IntegrationTests
     [SetUp]
     public void Setup()
     {
-        Environment.SetEnvironmentVariable("GITHUB_WEBHOOK_SECRET", HookSecret);
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "DUMMY");
-        Environment.SetEnvironmentVariable("DISCOURSE_CLIENT_API_KEY", "DUMMY");
-        Environment.SetEnvironmentVariable("DISCOURSE_CLIENT_USERNAME", "DUMMY");
-        Environment.SetEnvironmentVariable("DISCOURSE_DISCUSSION_CATEGORY", "0");
-        Environment.SetEnvironmentVariable("DISCOURSE_CLIENT_URL", "https://example.com/");
-
-
         _applicationFactory = new CustomWebApplicationFactory();
         _client = _applicationFactory.CreateClient();
     }

--- a/SS14.Labeller.Tests/SS14.Labeller.Tests.csproj
+++ b/SS14.Labeller.Tests/SS14.Labeller.Tests.csproj
@@ -25,4 +25,10 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/SS14.Labeller/Program.cs
+++ b/SS14.Labeller/Program.cs
@@ -1,9 +1,7 @@
 using System.Net.Http.Headers;
-using System.Runtime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using SS14.Labeller.Configuration;
-using SS14.Labeller.Configuration.Validators;
 using SS14.Labeller.DiscourseApi;
 using SS14.Labeller.GitHubApi;
 using SS14.Labeller.Handlers;

--- a/SS14.Labeller/Program.cs
+++ b/SS14.Labeller/Program.cs
@@ -1,6 +1,9 @@
 using System.Net.Http.Headers;
+using System.Runtime;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using SS14.Labeller.Configuration;
+using SS14.Labeller.Configuration.Validators;
 using SS14.Labeller.DiscourseApi;
 using SS14.Labeller.GitHubApi;
 using SS14.Labeller.Handlers;
@@ -13,15 +16,16 @@ public class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateSlimBuilder(args);
-        builder.Configuration.AddJsonFile("appsettings.json", false, true);
+        builder.Configuration.AddJsonFile("appsettings.json", true, true);
+        builder.Configuration.AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", true, true);
 
-        builder.Services.Configure<DiscourseConfig>(builder.Configuration.GetSection(DiscourseConfig.Name));
-        builder.Services.Configure<GitHubConfig>(builder.Configuration.GetSection(GitHubConfig.Name));
+        builder.Services.AddOptions<DiscourseConfig>()
+               .Bind(builder.Configuration.GetSection(DiscourseConfig.Name))
+               .ValidateDataAnnotations();
 
-        var githubConfig = new GitHubConfig();
-        builder.Configuration.Bind(GitHubConfig.Name, githubConfig);
-        var discourseConfig = new DiscourseConfig();
-        builder.Configuration.Bind(DiscourseConfig.Name, discourseConfig);
+        builder.Services.AddOptions<GitHubConfig>()
+               .Bind(builder.Configuration.GetSection(GitHubConfig.Name))
+               .ValidateDataAnnotations();
 
         builder.Services.ConfigureHttpJsonOptions(options =>
         {
@@ -35,14 +39,18 @@ public class Program
         {
             options.LoggingFields = Microsoft.AspNetCore.HttpLogging.HttpLoggingFields.All;
         });
-        builder.Services.AddHttpClient<IGitHubApiClient, GitHubApiClient>(client =>
+        builder.Services.AddHttpClient<IGitHubApiClient, GitHubApiClient>((sp, client) =>
         {
+            var githubConfig = sp.GetRequiredService<IOptions<GitHubConfig>>().Value;
+
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("SS14.Labeller", "1.0"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubConfig.Token);
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         });
-        builder.Services.AddHttpClient<IDiscourseClient, DiscourseClient>(client =>
+        builder.Services.AddHttpClient<IDiscourseClient, DiscourseClient>((sp, client) =>
         {
+            var discourseConfig = sp.GetRequiredService<IOptions<DiscourseConfig>>().Value;
+
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("SS14.Labeller", "1.0"));
             client.DefaultRequestHeaders.Add("Api-Key", discourseConfig.ApiKey);
             client.DefaultRequestHeaders.Add("Api-Username", discourseConfig.Username);
@@ -70,6 +78,7 @@ public class Program
                 HttpContext context,
                 [FromHeader(Name = "X-GitHub-Event")] string githubEvent,
                 [FromServices] IReadOnlyDictionary<string, RequestHandlerBase> handlers,
+                [FromServices] IOptions<GitHubConfig> githubConfig,
                 [FromServices] ILogger<Program> logger
             ) =>
             {
@@ -83,7 +92,7 @@ public class Program
                 var bodyBytes = memStream.ToArray();
 
                 var headers = request.Headers;
-                if (!SecurityHelper.IsRequestAuthorized(bodyBytes, githubConfig.WebhookSecret, headers, out var errorResponse))
+                if (!SecurityHelper.IsRequestAuthorized(bodyBytes, githubConfig.Value.WebhookSecret, headers, out var errorResponse))
                     return errorResponse;
 
                 if (handlers.TryGetValue(githubEvent, out var handler))


### PR DESCRIPTION
Fixed tests not being green
changed setting objects to be injected as IOptions (as god intended)
enabled settings validation
CHANGED APPSETTINGS TO BE OPTIONAL FILE (due to tests not being able to launch as Program.cs seeks appsettings.json IN HIS FOLDER and not in folder where tests are getting launched)
and added optional appsettings.{env}.json into config registration


TESTS ARE GREEN BUT THEY DONT TEST NEW CODE! THIS IS NOT NICE!